### PR TITLE
Update docs to #include "nvvk/raytraceKHR_vk.hpp" instead of "nvvk/raytrace_vk.hpp"

### DIFF
--- a/docs/vkrt_tutorial.md.htm
+++ b/docs/vkrt_tutorial.md.htm
@@ -233,19 +233,19 @@ with utility functions for building those acceleration structures. In the header
 
 ```` C
 // #VKRay
-#include "nvvk/raytrace_vk.hpp"
+#include "nvvk/raytraceKHR_vk.hpp"
 ````
 
 so that we can add that helper as a member in the `HelloVulkan` class,
 
 ```` C
-nvvk::RaytracingBuilder m_rtBuilder;
+nvvk::RaytracingBuilderKHR m_rtBuilder;
 ````
 
 and initialize it at the end of `initRaytracing()`:
 
 ```` C
-m_rtBuilder.setup(m_device, m_alloc, m_graphicsQueueIndex);
+m_rtBuilder.setup(m_device, &m_alloc, m_graphicsQueueIndex);
 ````
 
 !!! Note Memory Management
@@ -256,7 +256,7 @@ m_rtBuilder.setup(m_device, m_alloc, m_graphicsQueueIndex);
     This selects the simple one-`VkDeviceMemory`-per-object strategy, which is easier to understand for
     teaching purposes but not practical for production use.
 
-## Bottom-Level Acceleration Structureg
+## Bottom-Level Acceleration Structure
 
 The first step of building a BLAS object consists in converting the geometry data of an `ObjModel` into
 multiple structures consumed by the AS builder. We are holding all those structures under 


### PR DESCRIPTION
Great tutorial, thanks for putting it together! 

As I was going though the steps in https://nvpro-samples.github.io/vk_raytracing_tutorial_KHR/ I noticed it says to `#include "nvvk/raytrace_vk.hpp"`, but this file doesn't exist anymore. This PR changes it to `#include "nvvk/raytraceKHR_vk.hpp"` as well as changing `nvvk::RaytracingBuilder` to `nvvk::RaytracingBuilderKHR`. Also RaytracingBuilderKHR::setup() takes a pointer to the allocator.

All these changes have already been made in the completed version of the code: 
https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR/blob/9a174a8269abff96a8d0416e23e9556c1930f9c9/ray_tracing__simple/hello_vulkan.h#L37
https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR/blob/9a174a8269abff96a8d0416e23e9556c1930f9c9/ray_tracing__simple/hello_vulkan.h#L148
https://github.com/nvpro-samples/vk_raytracing_tutorial_KHR/blob/9a174a8269abff96a8d0416e23e9556c1930f9c9/ray_tracing__simple/hello_vulkan.cpp#L661