### PR TITLE
Fix code block indentation in "Adding Shaders"

### DIFF
--- a/docs/vkrt_tutorial.md.html
+++ b/docs/vkrt_tutorial.md.html
@@ -1239,7 +1239,7 @@ type is `VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR`, and only the `generalSha
 `VK_SHADER_UNUSED_KHR`. This is also the case for the callable shaders, not used in this tutorial. In our layout the ray
 generation comes first (0), followed by the miss shader (1).
 
-  ````C
+```` C
   // Shader groups
   VkRayTracingShaderGroupCreateInfoKHR group{VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR};
   group.anyHitShader       = VK_SHADER_UNUSED_KHR;
@@ -1256,7 +1256,6 @@ generation comes first (0), followed by the miss shader (1).
   group.type          = VK_RAY_TRACING_SHADER_GROUP_TYPE_GENERAL_KHR;
   group.generalShader = eMiss;
   m_rtShaderGroups.push_back(group);
-
 ````
 
 As detailed before, intersections are managed by 3 kinds of shaders: the intersection shader computes the ray-geometry


### PR DESCRIPTION
As you can see here currently this does not show up correctly and breaks the formatting of the entire paragraph:

![image](https://user-images.githubusercontent.com/24184732/124496417-ad3bd580-ddb9-11eb-9a62-f2a44b879430.png)
