### PR TITLE
Fix incorrect sbtRecordOffset

### DIFF
--- a/ray_tracing_anyhit/shaders/raytrace.rchit
+++ b/ray_tracing_anyhit/shaders/raytrace.rchit
@@ -121,7 +121,7 @@ void main()
     traceRayEXT(topLevelAS,  // acceleration structure
                 flags,       // rayFlags
                 0xFF,        // cullMask
-                0,           // sbtRecordOffset
+                1,           // sbtRecordOffset
                 0,           // sbtRecordStride
                 1,           // missIndex
                 origin,      // ray origin


### PR DESCRIPTION
This has to be 1 for the shadow version of the any hit shader to be used. This fixes the issue observed in https://gitlab.freedesktop.org/mesa/mesa/-/issues/6692 .