### PR TITLE
explicit include the stdint.h header for gcc 13

### DIFF
--- a/common/obj_loader.h
+++ b/common/obj_loader.h
@@ -20,6 +20,7 @@
 #pragma once
 #include "nvmath/nvmath.h"
 #include "tiny_obj_loader.h"
+#include <stdint.h>
 #include <array>
 #include <iostream>
 #include <unordered_map>


### PR DESCRIPTION
According to the https://gcc.gnu.org/gcc-13/porting_to.html, gcc 13 doesn't implicitly include `<stdint.h>` anymore, so we need to include it explicitly.