### PR TITLE
Fix indirect scissor README file

### DIFF
--- a/ray_tracing_indirect_scissor/README.md
+++ b/ray_tracing_indirect_scissor/README.md
@@ -9,7 +9,7 @@ and shadows, with a finite radius of effect. A compute shader will calculate
 scissor rectangles for each lantern, and an indirect trace rays command will
 dispatch rays for lanterns only within those scissor rectangles.
 
-[<h1>LINK TO FULL TUTORIAL</h1>](https://nvpro-samples.github.io/vk_raytracing_tutorial_KHR/vkrt_tuto_indirect_scissor.md.html)
+# [LINK TO FULL TUTORIAL](https://nvpro-samples.github.io/vk_raytracing_tutorial_KHR/vkrt_tuto_indirect_scissor.md.html)
 
 ![](../docs/Images/indirect_scissor/intro.png)
 


### PR DESCRIPTION
The indirect scissor readme file has a mix between markdown and HTML syntax that Github does not properly recognize. In order to access the tutorial you have to open the raw readme and get the tutorial url.

Fixed it so that it uses markdown syntax and the url is easily accessible from the pretty readme preview of github.