### PR TITLE
Fix ray_tracing_anyhit README incorrectly using ignoreIntersectionEXT as a function

### DIFF
--- a/ray_tracing_anyhit/README.md
+++ b/ray_tracing_anyhit/README.md
@@ -77,9 +77,9 @@ Now we will apply transparency:
 
 ~~~~ C++
   if (mat.dissolve == 0.0)
-      ignoreIntersectionEXT();
+      ignoreIntersectionEXT;
   else if(rnd(prd.seed) > mat.dissolve)
-     ignoreIntersectionEXT();
+     ignoreIntersectionEXT;
 }
 ~~~~
 


### PR DESCRIPTION
Hello,

Simple mistake that the shader source file corrects, but `ignoreIntersectionEXT` is not called as a function.