### PR TITLE
phase 4: m_allocator.destroyBuffer(m_sbtBuffer) called twice

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1111,7 +1111,6 @@ void createRayTracingPipeline()
     SCOPED_TIMER(__FUNCTION__);
 
     // For re-creation
-    m_allocator.destroyBuffer(m_sbtBuffer);
     vkDestroyPipeline(m_app->getDevice(), m_rtPipeline, nullptr);
     vkDestroyPipelineLayout(m_app->getDevice(), m_rtPipelineLayout, nullptr);
 


### PR DESCRIPTION
in phase 4 m_allocator.destroyBuffer(m_sbtBuffer) is called twice

once in createRayTracingPipeline()
and again when createRayTracingPipeline() calls createShaderBindingTable().

the buffer is only used and recreated inside createShaderBindingTable() so it should be safe to remove the destructor in createRayTracingPipeline()

in phase 5 the code behaves like this and destroys it once in createShaderBindingTable()